### PR TITLE
Kafaka | adding unsubscribe

### DIFF
--- a/automation/devops_automation_infra/plugins/kafka.py
+++ b/automation/devops_automation_infra/plugins/kafka.py
@@ -89,6 +89,7 @@ class Kafka(TunneledPlugin):
             msg = self.consumer.poll(timeout=1)
             if msg is not None:
                 list_of_msg.append(msg)
+        self.consumer.unsubscribe()
         return list_of_msg
 
     def consume_iter(self, topics, timeout=None, commit=False):
@@ -122,6 +123,7 @@ class Kafka(TunneledPlugin):
         except Exception as e:
             logging.exception(f"Error in consume_iter")
         finally:
+            self.consumer.unsubscribe()
             logging.info(f"Stopping to consume topics {topics}")
 
     def parse_message(self, msg):


### PR DESCRIPTION
Issue:
Before every consume function we subscribling to one or more topics,
but we dont unsubscribe from those topics.
if we dont unsubscribe and the test still has another
logic that takes some time (300seconds approx.)
we might get this exception:
MAX_POLL_EXCEEDED after max.poll.interval.ms

Solution:
Adding unsubsribe methos wich cut off the subscription.