### PR TITLE
Bug fix k8s networking test

### DIFF
--- a/automation/devops_automation_infra/utils/k8s_utils.py
+++ b/automation/devops_automation_infra/utils/k8s_utils.py
@@ -1,7 +1,7 @@
-from automation_infra.utils.waiter import wait_for_predicate_nothrow
+from automation_infra.utils.waiter import wait_for_predicate
 
 
 def create_deployment_with_replicas(host, name, docker_image, amount_of_replicas):
-    wait_for_predicate_nothrow(lambda: host.K8s.create_deployment(name, docker_image), timeout=120)
+    wait_for_predicate(lambda: host.K8s.create_deployment(name, docker_image), timeout=120)
     host.K8s.scale_deployment(name, int(amount_of_replicas))
     host.K8s.expose_deployment(name)


### PR DESCRIPTION
Fixed bug in the k8s_util which would mean the test would fail to create the deployment because the waiter function used would only retry in case the predicate would return None and since the create function returns false the predicate would pass but the deployment be created.
Change the waiter function used from wait_for_predicate_nothrow to  wait_for_predicate.