### PR TITLE
Seaweed plugin | bug fix - dns name in k8s mode was wrong

### DIFF
--- a/automation/devops_automation_infra/plugins/seaweed.py
+++ b/automation/devops_automation_infra/plugins/seaweed.py
@@ -9,7 +9,7 @@ import os
 class Seaweed(TunneledPlugin):
     def __init__(self, host):
         super().__init__(host)
-        self.DNS_NAME = 'seaweedfs-s3-localnode.tls.ai' if not helpers.is_k8s(self._host.SshDirect) else 'seaweedfs-s3-localnode.default.svc.cluster.local'
+        self.DNS_NAME = 'seaweedfs-s3-localnode.tls.ai' if not helpers.is_k8s(self._host.SshDirect) else 'seaweedfs-s3.default.svc.cluster.local'
         self.PORT = 8333
         self._client = None
 


### PR DESCRIPTION
We were unable to connect to the host under test s3 seaweed.
The dns name set when creating the ssh tunnel was in correct