### PR TITLE
K8s plugin add keys to config map

### DIFF
--- a/automation/devops_automation_infra/tests/test_k8s_networking.py
+++ b/automation/devops_automation_infra/tests/test_k8s_networking.py
@@ -28,7 +28,7 @@ def test_cluster_network_master_restart(base_config,
     base_config.hosts.host1.SshDirect.connect(timeout=60)
     create_deployment_with_replicas(base_config.hosts.host1, deployment_name, docker_image_name, amount_of_replicas)
     wait_for_predicate(
-        lambda: base_config.hosts.host1.K8s.get_ready_deployment_pods(deployment_name) == amount_of_replicas,
+        lambda: base_config.hosts.host1.K8s.number_ready_pods_in_deployment(deployment_name) == amount_of_replicas,
         timeout=300)
     base_config.hosts.host1.Power.reboot()
     # Check host has started again

--- a/automation/devops_automation_infra/utils/cmd_utils.py
+++ b/automation/devops_automation_infra/utils/cmd_utils.py
@@ -9,3 +9,4 @@ def convert_kwargs_to_options_string(kwargs, format_with_equals_sign=False):
         return result_string
     except AttributeError:
         return kwargs
+

--- a/automation/devops_automation_infra/utils/k8s_utils.py
+++ b/automation/devops_automation_infra/utils/k8s_utils.py
@@ -1,3 +1,5 @@
+import json
+
 from automation_infra.utils.waiter import wait_for_predicate
 
 
@@ -5,3 +7,10 @@ def create_deployment_with_replicas(host, name, docker_image, amount_of_replicas
     wait_for_predicate(lambda: host.K8s.create_deployment(name, docker_image), timeout=120)
     host.K8s.scale_deployment(name, int(amount_of_replicas))
     host.K8s.expose_deployment(name)
+
+
+def write_configmap_json_to_tmp_dir(configmap_file_name, configmap_json):
+    with open(f"/tmp/{configmap_file_name}", "w") as config_map_file:
+        json.dump(configmap_json, config_map_file)
+    return f"/tmp/{configmap_file_name}"
+


### PR DESCRIPTION
Added  the ability to edit a configmap of a resource to the k8s.
Which includes the following steps 
1. get configmap name
2. edit the existing configmap
3. saving the edited copy to the host testing 
4. uploading the copy to the host under test
5. replacing the old confgimap
6. restarting the pod (deleting the pod and waiting for a new one to start)