### PR TITLE
utils/consul/backup_consul_keys: restore from backup only if there is…

### DIFF
--- a/automation/devops_automation_infra/utils/consul.py
+++ b/automation/devops_automation_infra/utils/consul.py
@@ -19,7 +19,9 @@ def backup_consul_keys(host):
             with open("keys.tmp", "rb") as f:
                 all_default_keys_dict = pickle.load(f)
             os.remove("keys.tmp")
-            consul.reset_state(all_default_keys_dict) #restore keys from backup file
+            current_keys = consul.get_all_keys()
+            if current_keys != all_default_keys_dict:
+                consul.reset_state(all_default_keys_dict) #restore keys from backup file
             sshdirect.execute(f"rm -f {work_dir}/all_default_keys.pickle")
 
         except SSHCalledProcessError as e:


### PR DESCRIPTION
… a difference

Pipeng has a listener on consul keys so when the keys are changed pipeng
restarts and then takes ~1min to be ready. Unnecessarily restoring keys
causes an unnecessary restart of pipeng and therefore a long
clean_between_tests runtime.