### PR TITLE
compose: prevent pull logs to garbage logs.

### DIFF
--- a/automation/devops_automation_infra/plugins/docker_compose.py
+++ b/automation/devops_automation_infra/plugins/docker_compose.py
@@ -26,7 +26,7 @@ class DockerCompose(object):
 
     def compose_pull(self, compose_file_path):
         logging.debug(f"pulling docker images from compose {compose_file_path}")
-        self._ssh_direct.execute(f'{self.compose_bin_path} -f {compose_file_path} pull', timeout=60*60)
+        self._ssh_direct.execute(f'{self.compose_bin_path} -f {compose_file_path} pull -q', timeout=60*60)
 
     def compose_up(self, compose_file_path, *services):
         services_cmd = " ".join(services)


### PR DESCRIPTION
Currently logs of pull (especially in case of failure) are garbaging the
consule output (they span like in thousands lines). The fix is to
prevent status priting of pull