### PR TITLE
docker: truncate running container logs

### DIFF
--- a/automation/devops_automation_infra/plugins/docker.py
+++ b/automation/devops_automation_infra/plugins/docker.py
@@ -91,5 +91,8 @@ class Docker(object):
         cmd = f"{self._docker_bin} run {docker_args} --network {network} {image_name}"
         self._ssh_direct.execute(cmd, timeout=10000)
 
+    def clear_logs(self):
+        self._ssh_direct.execute("sudo truncate -s 0 /var/lib/docker/containers/*/*-json.log")
+
 
 plugins.register("Docker", Docker)


### PR DESCRIPTION
This method is usefull not to get all the container logs all the time in
case of subsequent tests. So the idea is that we can truncate the docker
logs between the tests and only get logs of current test run when
manually running docker logs