### PR TITLE
Fix awk commands in run_cmd_in_service

### DIFF
--- a/automation/devops_automation_infra/plugins/docker.py
+++ b/automation/devops_automation_infra/plugins/docker.py
@@ -43,8 +43,8 @@ class Docker(object):
         self._ssh_direct.execute(cmd)
 
     def run_cmd_in_service(self, service_name, cmd):
-        cmd_escaped = cmd.replace('"', '\\"')
-        cmd = self._running_container_by_name_cmd(service_name) + f"| xargs -I{{}} {self._docker_bin} exec {{}} sh -c \"{cmd_escaped}\""
+        cmd_escaped = cmd.replace("'", "\\'")
+        cmd = self._running_container_by_name_cmd(service_name) + f"| xargs -I{{}} {self._docker_bin} exec {{}} sh -c $'{cmd_escaped}'"
         return self._ssh_direct.execute(cmd).strip()
 
     def service_ip_address(self, service_name):


### PR DESCRIPTION
Use string literal (instead of semi-literal) for running docker cmds, to resolve issue where awk commands became invalid due to escaping.

more info:
https://riptutorial.com/bash/example/2465/quoting-literal-text