### PR TITLE
seaweed: inherit from resource_manager instead of the opposite.

### DIFF
--- a/automation/devops_automation_infra/plugins/seaweed.py
+++ b/automation/devops_automation_infra/plugins/seaweed.py
@@ -2,23 +2,22 @@ import logging
 import tempfile
 
 from infra.model import plugins
-from automation_infra.plugins.base_plugin import TunneledPlugin
 from pytest_automation_infra import helpers
 from botocore.exceptions import ClientError
 import boto3
 import os
 
+from automation_infra.plugins.resource_manager import ResourceManager
 
-class Seaweed(object):
+
+class Seaweed(ResourceManager):
     def __init__(self, host):
+        super().__init__(host)
         self._host = host
         self.DNS_NAME = 'seaweedfs-s3-localnode.tls.ai' if not helpers.is_k8s(self._host.SshDirect) else 'seaweedfs-s3.default.svc.cluster.local'
         self.filer_host = 'seaweedfs-filer-localnode.tls.ai' if not helpers.is_k8s(self._host.SshDirect) else 'seaweedfs-filer.default.svc.cluster.local'
         self.filer_port = 8888
         self.PORT = 8333
-        self._client = None
-        self._resource = None
-
 
     @property
     def tunnel(self):
@@ -49,84 +48,10 @@ class Seaweed(object):
                           aws_secret_access_key='any',
                           aws_access_key_id='any')
 
-
     def _s3_resource(self):
         return boto3.resource('s3', endpoint_url=self._endpoint_uri(),
                           aws_secret_access_key='any',
                           aws_access_key_id='any')
-
-    def get_bucket_files(self, bucket_name, recursive=True):
-        return self.get_files_by_prefix(bucket_name, '', recursive)
-
-    def get_all_buckets(self):
-        return list(self.resource.buckets.all())
-
-    def get_files_by_prefix(self, bucket_name, prefix, recursive=True):
-        res = self.client.list_objects(Bucket=bucket_name, Prefix=prefix)
-        res_code = res['ResponseMetadata']['HTTPStatusCode']
-        assert res_code == 200
-        files = [x['Key'] for x in res.get('Contents', [])]
-        if not recursive:
-            return files
-        for x in res.get('CommonPrefixes', []):
-            prefix = x['Prefix']
-            files.extend(self.get_files_by_prefix(bucket_name, prefix))
-        return files
-
-    def create_bucket(self, bucket_name):
-        res = self.client.create_bucket(Bucket=bucket_name)
-        res_code = res['ResponseMetadata']['HTTPStatusCode']
-        assert res_code == 200
-
-    def delete_bucket(self, bucket_name):
-        res = self.client.delete_bucket(Bucket=bucket_name)
-        res_code = res['ResponseMetadata']['HTTPStatusCode']
-        assert res_code == 204
-
-    def upload_file_to_bucket(self, src_file_path, dst_bucket, ds_file_name):
-        res = self.client.upload_file(src_file_path, dst_bucket, ds_file_name)
-        assert res is None
-
-    def upload_fileobj(self, file_obj, dst_bucket, dst_filepath):
-        res = self.client.upload_fileobj(file_obj, dst_bucket, dst_filepath)
-        assert res is None
-
-    def upload_files_from(self, path, dst_bucket):
-        self.create_bucket(dst_bucket)
-        src_files = os.listdir(path)
-        dst_files = self.get_bucket_files(dst_bucket)
-        missing_files = [item for item in src_files if item not in dst_files]
-        for _file in missing_files:
-            self.upload_file_to_bucket(path + _file, dst_bucket, _file)
-
-    def file_exists(self, bucket_name, file_name):
-        try:
-            self.client.head_object(Bucket=bucket_name, Key=file_name)
-        except ClientError:
-            return False
-        else:
-            return True
-        
-    def file_content(self, bucket_name, key):
-        res = self.client.get_object(Bucket=bucket_name, Key=key)
-        assert res['ResponseMetadata']['HTTPStatusCode'] == 200
-        return res['Body'].read()
-
-    def check_video_path(self, bucket_name, key):
-        res = self.client.get_object(Bucket=bucket_name, Key=key)
-        assert res['ResponseMetadata']['HTTPStatusCode'] == 200
-        return res
-
-    def get_files_in_dir(self, bucket_name, dir_path):
-        result = []
-        resp = self.client.list_objects_v2(Bucket=bucket_name, Prefix=dir_path, Delimiter='/')
-        if 'Contents' not in resp.keys():
-            return
-        return [obj['Key'] for obj in resp['Contents']]
-
-    def delete_file(self, bucket_name, file_name):
-        self.client.delete_object(Bucket=bucket_name, Key=file_name)
-        assert not self.file_exists(bucket_name, file_name)
 
     def ping(self):
         self.get_all_buckets()


### PR DESCRIPTION
Up until now, the resource_manager plugin inherited from the seaweed
plugin (which sits in devops-infra repo), in order to take advantage of
some methods which were implemented there, and because the resource
manager is actually also an s3 object storage.
The problem with that is that it creates a dependency for infra repo on
devops-infra repo, when really it should be the other way around, ie
devops-infra (and seaweed) can depend on infra. So this would cause
test_resource_manager to fail in a situation where it wasnt cloned
together with devops-infra repo.

The solution was to move the shared methods to the resource_manager
plugin, and change the seaweed plugin (in devops-repo) to inherit from
resource_manager.Up until now, the resource_manager plugin inherited from the seaweed
plugin (which sits in devops-infra repo), in order to take advantage of
some methods which were implemented there, and because the resource
manager is actually also an s3 object storage.
The problem with that is that it creates a dependency for infra repo on
devops-infra repo, when really it should be the other way around, ie
devops-infra (and seaweed) can depend on infra. So this would cause
test_resource_manager to fail in a situation where it wasnt cloned
together with devops-infra repo.

The solution was to move the shared methods to the resource_manager
plugin, and change the seaweed plugin (in devops-repo) to inherit from
resource_manager.