### PR TITLE
infra: fix copy files from host running tests to container.

### DIFF
--- a/automation/devops_automation_infra/plugins/docker.py
+++ b/automation/devops_automation_infra/plugins/docker.py
@@ -60,8 +60,10 @@ class Docker(object):
         self._ssh_direct.execute(cmd, timeout=timeout_command)
 
     def copy_file_to_container(self, service_name, file_path, docker_dest_path):
+        remote_file = self._host.mktemp()
+        self._host.SshDirect.upload(file_path, remote_file)
         container_name = self.container_by_name(service_name)
-        cmd = f'{self._docker_bin} cp {file_path} {container_name}:{docker_dest_path}'
+        cmd = f'{self._docker_bin} cp {remote_file} {container_name}:{docker_dest_path}'
         self._ssh_direct.execute(cmd)
 
     def _first_network_by_name(self, name_regex):

--- a/automation/devops_automation_infra/tests/docker_tests/test_docker.py
+++ b/automation/devops_automation_infra/tests/docker_tests/test_docker.py
@@ -1,0 +1,18 @@
+import logging
+
+from devops_automation_infra.plugins import docker
+from pytest_automation_infra.helpers import hardware_config
+import tempfile
+
+
+@hardware_config(hardware={"host": {}})
+def test_docker(base_config):
+    temp = tempfile.NamedTemporaryFile(delete=True)
+    temp.write(b'Sasha king')
+    temp.flush()
+    logging.info("write somethinh to proxy container")
+    base_config.hosts.host.Docker.copy_file_to_container("automation_proxy", temp.name, "/tmp/test_file")
+    logging.info("Read from proxy container")
+    content = base_config.hosts.host.SSH.get_contents("/tmp/test_file")
+    assert content == b"Sasha king"
+    temp.close()


### PR DESCRIPTION
Currently writing to container was incorrect and worked only in case
host running test and host under test were running on the same machine.
The reason for that was that we cannot copy file from remote host to the
docker running on some other host. File must be first copied to the
"host under test" and then moved to the container itself.
Fixes: a1757a9 ("add copy file to container function")