### PR TITLE
use host's ip if container is in host-mode

### DIFF
--- a/automation/devops_automation_infra/utils/host.py
+++ b/automation/devops_automation_infra/utils/host.py
@@ -1,0 +1,8 @@
+def get_default_net_interface(host):
+    cmd = "ip route | grep default | cut -d' ' -f 5"
+    return host.SshDirect.execute(cmd).strip()
+
+
+def get_host_ip(host):
+    cmd = f"ip addr show | grep '{get_default_net_interface(host)}' | grep  -Po 'inet \\K(\\d+\\.?){{4}}'"
+    return host.SshDirect.execute(cmd).strip()


### PR DESCRIPTION
if a service is found but has no ip, it is assumed to be in host-mode.
"container does not have its own IP-address when using host mode networking"
(from https://docs.docker.com/network/host/)