### PR TITLE
docker.py: added debug logging in case of failure of command

### DIFF
--- a/automation/devops_automation_infra/plugins/docker.py
+++ b/automation/devops_automation_infra/plugins/docker.py
@@ -34,22 +34,22 @@ class Docker(object):
     def restart_container_by_service_name(self, service_name):
         logging.debug(f"restarting container {service_name}")
         cmd = self._container_by_name_cmd(service_name) + f"| xargs --no-run-if-empty {self._docker_bin} restart"
-        self._ssh_direct.execute(cmd)
+        self.try_executing_and_verbosely_log_error(cmd)
 
     def kill_container_by_service(self, service_name, signal='KILL'):
         logging.debug(f"Kill container {service_name}")
         cmd = self._running_container_by_name_cmd(
             service_name) + f"| xargs --no-run-if-empty {self._docker_bin} kill --signal={signal}"
-        self._ssh_direct.execute(cmd)
+        self.try_executing_and_verbosely_log_error(cmd)
 
     def run_container_by_service(self, servce_name):
         cmd = self._container_by_name_cmd(servce_name) + f"| xargs -I{{}} {self._docker_bin} start {{}}"
-        self._ssh_direct.execute(cmd)
+        self.try_executing_and_verbosely_log_error(cmd)
 
     def run_cmd_in_service(self, service_name, cmd):
         cmd_escaped = cmd.replace("'", "\\'")
         cmd = self._running_container_by_name_cmd(service_name) + f"| xargs -I{{}} {self._docker_bin} exec {{}} sh -c $'{cmd_escaped}'"
-        return self._ssh_direct.execute(cmd).strip()
+        return self.try_executing_and_verbosely_log_error(cmd).strip()
 
     def service_ip_address(self, service_name):
         cmd = self._running_container_by_name_cmd(
@@ -63,7 +63,7 @@ class Docker(object):
     def wait_container_down(self, name_regex, timeout_command=100):
         container_name = self.container_by_name(name_regex)
         cmd = f'{self._docker_bin} wait {container_name}'
-        self._ssh_direct.execute(cmd, timeout=timeout_command)
+        self.try_executing_and_verbosely_log_error(cmd, timeout=timeout_command)
 
     def copy_file_to_container(self, service_name, file_path, docker_dest_path):
         filename = file_path.split("/")[-1]
@@ -73,7 +73,7 @@ class Docker(object):
         container_name = self.container_by_name(service_name)
 
         cmd = f'{self._docker_bin} cp {remote_file} {container_name}:{docker_dest_path}'
-        self._ssh_direct.execute(cmd)
+        self.try_executing_and_verbosely_log_error(cmd)
 
     def _first_network_by_name(self, name_regex):
         """
@@ -86,7 +86,7 @@ class Docker(object):
     def _first_image_by_name(self, name_regex):
         container_name = self.container_by_name(name_regex)
         cmd = f'{self._docker_bin} inspect --format="{{{{.Config.Image}}}}" {container_name}'
-        execute = self._ssh_direct.execute(cmd).strip()
+        execute = self.try_executing_and_verbosely_log_error(cmd).strip()
         return execute
 
     def container_by_name(self, name_regex):
@@ -94,7 +94,7 @@ class Docker(object):
 
     def remove_containers_by_name(self, *container_names):
         cmd = f"{self._docker_bin} rm -f {' '.join(container_names)}"
-        self._ssh_direct.execute(cmd, timeout=100)
+        self.try_executing_and_verbosely_log_error(cmd, timeout=100)
 
     def run_container_by_service_with_env(self, service_name, envs={}, remove_container_after_execute=False,
                                           is_detach_mode=True, **kwargs):
@@ -110,34 +110,45 @@ class Docker(object):
         if is_detach_mode:
             docker_args += ' -d '
         cmd = f"{self._docker_bin} run {docker_args} --network {network} {image_name}"
-        self._ssh_direct.execute(cmd, timeout=10000)
+        self.try_executing_and_verbosely_log_error(cmd, timeout=10000)
 
     def stop_all_containers(self):
         cmd = f"{self._docker_bin} stop $({self._docker_bin} ps -a -q)"
-        self._ssh_direct.execute(cmd, timeout=100)
+        self.try_executing_and_verbosely_log_error(cmd, timeout=100)
 
     def number_of_running_containers(self):
         cmd = f"{self._docker_bin} ps | wc -l"
-        result = self._ssh_direct.execute(cmd, timeout=100)
+        result = self.try_executing_and_verbosely_log_error(cmd, timeout=100)
         return 0 if result == 1 else result - 1
 
     def stop_container(self, name_regex):
         service_name = self.container_by_name(name_regex)
         cmd = f"{self._docker_bin} stop {service_name}"
-        self._ssh_direct.execute(cmd, timeout=100)
+        self.try_executing_and_verbosely_log_error(cmd, timeout=100)
 
     def start_container(self, name_regex):
         service_name = self.container_by_name(name_regex)
         cmd = f"{self._docker_bin} start {service_name}"
-        self._ssh_direct.execute(cmd, timeout=100)
+        self.try_executing_and_verbosely_log_error(cmd, timeout=100)
 
     def is_container_up(self, name_regex):
         service_name = self.container_by_name(name_regex)
         cmd = f"{self._docker_bin} inspect -f '{{{{.State.Running}}}}' {service_name}"
-        return self._ssh_direct.execute(cmd, timeout=100).strip() == 'true'
+        return self.try_executing_and_verbosely_log_error(cmd, timeout=100).strip() == 'true'
 
     def wait_container_up(self, name_regex, timeout=60, interval=1):
         wait_for_predicate_nothrow(lambda: self.is_container_up(name_regex), timeout=timeout, interval=interval)
+
+    def try_executing_and_verbosely_log_error(self, cmd, timeout=None):
+        try:
+            return self._ssh_direct.execute(cmd, timeout=timeout)
+        except:
+            logging.exception(f"caught exception trying to execute command: {cmd}")
+            logging.info(f"docker ps output: {self._ssh_direct.execute(f'{self._docker_bin} ps')}")
+            logging.info(f"sudo netstat -ntlp | grep docker: {self._ssh_direct.execute('sudo netstat -ntlp | grep docker')}")
+            logging.info(f"sudo ps -ef | grep docker | grep port: {self._ssh_direct.execute('sudo ps -ef | grep docker | grep port')}")
+            raise
+
 
 
 plugins.register("Docker", Docker)


### PR DESCRIPTION
When there is a docker command failure, we dont really have anything to
do to figure out what went wrong, other than re-run the test.

So instead of just executing, whenever running a docker command, if an
exception is raised I also log the output of the following:
docker ps
sudo ps -ef | grep docker | grep port
sudo netstat -ntlp | grep dockersudo netstat -ntlp | grep docker