### PR TITLE
Consul plugin: add folder option on all keys getter

### DIFF
--- a/automation/devops_automation_infra/plugins/consul.py
+++ b/automation/devops_automation_infra/plugins/consul.py
@@ -98,8 +98,8 @@ class Consul(object):
             raise Exception("Failed leader is unspecified")
         return leader
 
-    def get_all_keys(self):
-        _, data = self._consul.kv.get("", recurse=True)
+    def get_all_keys(self, folder=""):
+        _, data = self._consul.kv.get(folder, recurse=True)
         if data is None:
             return None
         return dict((x['Key'], x['Value']) for x in data)


### PR DESCRIPTION
Added a folder option on all keys getter to be able to get all keys within defined folder path