### PR TITLE
Docker plugin : add functionllity to wait for status x times

### DIFF
--- a/automation/devops_automation_infra/plugins/docker.py
+++ b/automation/devops_automation_infra/plugins/docker.py
@@ -1,5 +1,6 @@
 import logging
 from distutils.util import strtobool
+import time
 
 from automation_infra.utils.waiter import wait_for_predicate_nothrow
 from infra.model import plugins
@@ -88,6 +89,17 @@ class Docker(object):
 
     def wait_for_container_status(self, name_regex, status, timeout=100):
         waiter.wait_for_predicate(lambda: self.get_container_status(name_regex) == status, timeout=timeout)
+
+    def wait_service_status_x_times(self, container_regex, status, times=5, interval=1, timeout=60):
+        success_counter = 0
+        before = time.time()
+        while success_counter <= times:
+            if time.time() - before > timeout:
+                raise TimeoutError(f"Time has over , got {success_counter} succeed times")
+            if self.get_container_status(container_regex) == status:
+                success_counter += 1
+            time.sleep(interval)
+
 
     def copy_file_to_container(self, service_name, file_path, docker_dest_path):
         filename = file_path.split("/")[-1]


### PR DESCRIPTION
currently we have problem with restart container
wait_for_container up not giving in this situation required behavior.
cause container might continue to reset himself and we won't catch it in
wait_for_container_up.
in this new function we check container is up x times with docker
inspect status