### PR TITLE
tunnel: fix the ip of the tunnel we create.

### DIFF
--- a/automation/devops_automation_infra/plugins/kafka.py
+++ b/automation/devops_automation_infra/plugins/kafka.py
@@ -37,7 +37,7 @@ class Kafka(object):
             raise
 
     def _create_connection(self):
-        tunnel = self._host.TunnelManager.get_or_create('kafka', self._host.ip, Kafka.RPYC_PORT)
+        tunnel = self._host.TunnelManager.get_or_create('kafka', "localhost", Kafka.RPYC_PORT)
         return waiter.wait_for_predicate_nothrow(
             lambda: rpyc.connect(*tunnel.host_port, config={'allow_all_attrs': True, 'sync_request_timeout': 120}),
             timeout=10)


### PR DESCRIPTION
Currently the endpoint of the tunnel is defined as the host under test,
this is incorrect as the endpoint of the tunnel is actually "local" to
that host (it is automation infra container that is running kafka proxy
server).
This does not work on AWS, where the external IP of the host cannot be
used for host to host communication. (external IP is not resolvable from
within the host itself), and therefore tunnel target cannot be the
external ip of the host