### PR TITLE
Add external host IP getter

### DIFF
--- a/automation/devops_automation_infra/utils/host.py
+++ b/automation/devops_automation_infra/utils/host.py
@@ -1,3 +1,6 @@
+from requests import get
+
+
 def get_default_net_interface(host):
     cmd = "ip route | grep default | cut -d' ' -f 5"
     return host.SshDirect.execute(cmd).strip()
@@ -6,3 +9,7 @@ def get_default_net_interface(host):
 def get_host_ip(host):
     cmd = f"ip addr show | grep '{get_default_net_interface(host)}' | grep  -Po 'inet \\K(\\d+\\.?){{4}}'"
     return host.SshDirect.execute(cmd).strip()
+
+
+def get_external_host_ip():
+    return get('https://api.ipify.org').text


### PR DESCRIPTION
Added external host IP getter for camera-service direct requests. It took internal IP which was the reason of connection error. Added a function to get external IP by using url AWS documentation suggested to get EC2 external IP