### PR TITLE
weed: solve OOM issue when passing large artifacts from AWS to local S3.

### DIFF
--- a/automation/devops_automation_infra/tests/docker_tests/test_seaweed.py
+++ b/automation/devops_automation_infra/tests/docker_tests/test_seaweed.py
@@ -8,7 +8,20 @@ from devops_automation_infra.plugins.seaweed import Seaweed
 from pytest_automation_infra.helpers import hardware_config
 
 
+def _test_deploy_to_s3(host):
+    logging.info("trying to upload to s3")
+    host.Seaweed.deploy_resource_to_s3("core/images/angledfaces.jpg", "tmp/multipart.jpg")
+    aws_content = host.ResourceManager.file_content("anyvision-testing", "core/images/angledfaces.jpg")
+    local_content = host.Seaweed.get_raw_resource("tmp/multipart.jpg", bucket="automation_infra")
+    assert aws_content == local_content
+    logging.info("trying with small chunk size")
+    host.Seaweed.deploy_resource_to_s3("core/images/angledfaces.jpg", "tmp/multipart1.jpg", chunk_size=1024)
+    local_content = host.Seaweed.get_raw_resource("tmp/multipart1.jpg", bucket="automation_infra")
+    assert aws_content == local_content
+
+
 @hardware_config(hardware={"host": {}})
 def test_basic(base_config):
     seaweed = base_config.hosts.host.Seaweed
     seaweed.verify_functionality()
+    _test_deploy_to_s3(base_config.hosts.host)


### PR DESCRIPTION
Currently we have an OOM in our tests  when passing large artifacts from
AWS to local S3. this is caused due to the fact that we first read the
whole object to memory and then try to upload it to local s3. For large
files this obviously does not work and we get an OOM.
Solution is to use multipart download/upload to avoid keeping the object
as a whole in memory