### PR TITLE
docker: pass exposed ports from original container env.

### DIFF
--- a/automation/devops_automation_infra/plugins/docker.py
+++ b/automation/devops_automation_infra/plugins/docker.py
@@ -79,6 +79,8 @@ class Docker(object):
 
     def wait_container_down(self, name_regex, timeout_command=100):
         container_name = self.container_by_name(name_regex)
+        if not container_name:
+            return
         cmd = f'{self._docker_bin} wait {container_name}'
         self.try_executing_and_verbosely_log_error(cmd, timeout=timeout_command)
 


### PR DESCRIPTION
Currently when restarting service with overwrite_and_run_container_by_service_with_env
we dont account for exposed ports and ports become unexposed.
The fix is to account for exposed ports as well