### PR TITLE
compose pull: retry pull compose to overcome network errors.

### DIFF
--- a/automation/devops_automation_infra/plugins/docker_compose.py
+++ b/automation/devops_automation_infra/plugins/docker_compose.py
@@ -6,7 +6,7 @@ from infra.model import plugins
 from automation_infra.plugins.ssh_direct import SshDirect, SSHCalledProcessError
 from pytest_automation_infra.helpers import hardware_config
 import packaging.version
-
+from retry import retry
 
 class DockerCompose(object):
 
@@ -29,6 +29,7 @@ class DockerCompose(object):
         logging.debug(f"stopping compose {compose_file_path}")
         self._ssh_direct.execute(f'{self.compose_bin_path} -f {compose_file_path} down', timeout=60 * 20)
 
+    @retry(tries=5, delay=30, backoff=2)
     def compose_pull(self, compose_file_path):
         logging.debug(f"pulling docker images from compose {compose_file_path}")
         self._ssh_direct.execute(f'{self.compose_bin_path} -f {compose_file_path} pull -q', timeout=60 * 60)


### PR DESCRIPTION
We had a stack trace of
E           automation_infra.plugins.ssh_direct.SSHCalledProcessError: Command '/usr/local/bin/docker-compose -f /home/ubuntu/compose_v2/docker-compose-core-gpu.yml pull -q' on host 54.171.168.44 returned non-zero exit status 1
E           stdout:
E           stderr:
E           ERROR: for load-balancer-init  Get https://gcr.io/v2/anyvision-training/load-balancer-init/manifests/master-2.3.1: Get https://gcr.io/v2/token?account=_json_key&scope=repository%3Aanyvision-training%2Fload-balancer-init%3Apull&service=gcr.io: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
E
E           ERROR: for core-cleaner-orchestrator-init  error pulling image configuration: Get https://storage.googleapis.com/artifacts.anyvision-training.appspot.com/containers/images/sha256:f667a3117e5d951ca612f3de765213db44ad21ebe003312ee51bf574fae86056?Expires=1613527279&GoogleAccessId=185186972438-compute@developer.gserviceaccount.com&Signature=UVLH/vdkS1c6eDYIdNjpNKbfsAqSD0H7Y1tXgflBk9/zjXwqByDEG215ZiRpRbYWBOtdrJVZyLkpyfsaJh9FbEnZ9c3mcLVtCn%2BfQaxGBrasUFY7EtY87d19uXpyqkRb5kOe6S7bS3UtLErTyBnV/11yEzYS7YnbFnoSR%2Bu/2Y1Ru4i8PCy1yx5sDcS3Ng7H4of9k7LbuG4QNKZt5eAFLvYSFd%2B3nKSV0aplRAlD3FhuBhW1UOqgaxDrGVbi6Zufb%2BDteQzqOT/eVfISQJcinNdVefKw6Nvw%2BBobbMFZ0kx8hydoFzZAO0x7ygU/TEH53Re%2BWpDTg95gVCD5WJcuNQ%3D%3D: dial tcp 74.125.193.128:443: i/o timeout
E
E           ERROR: for collate-service  error pulling image configuration: Get https://storage.googleapis.com/artifacts.anyvision-training.appspot.com/containers/images/sha256:2200314221a24a998ae28f0d05bfff9c75859dfeac7dd7d62ee003bb6284739b?Expires=1613527352&GoogleAccessId=185186972438-compute@developer.gserviceaccount.com&Signature=CdEJKkaVw20V1wxmbV8xSy9wt5ILTze7dq95MJPtugtik/iBs0XfMZlD9ib30Mwx%2Buwnrc8nm4FFBtkDQvOCYkVJVAcyGIf2I%2BbYb3xRDqU/Gsd2w0KpYqcOIBCfEe0qwtYR8YF68lbtpctGs03eWXAnFmjTgVuVXMxe8IB7j4LV1wm90%2Bpghg%2B5Pfqp4IeBu4QB7Zm1HwlS%2BnnDGrj/pXm3WKZKvuf0P5aLnQ6hk7cKUkuxY8ajJjR5ZsGcAXBhCzlHYJ1nqXkuDw5A7vpmsD2AQo0AGqNS5wM30oTat6YYIngGS453Rhu2B5zaAYzh2vFk9gr04vX3M3QlEGM/FQ%3D%3D: dial tcp 74.125.193.128:443: i/o timeout
E
E           ERROR: for camera-service  error pulling image configuration: Get https://gcr.io/v2/anyvision-training/camera-service/blobs/sha256:330c26aee19a9ea4416f0500d1c1d2975f5243fcce2121bbcaf96fd21b38ad0b: read tcp 10.83.1.106:35654->74.125.193.82:443: read: connection reset by peer
E

Lets add a retry in a hope that this will fix the errors