### PR TITLE
consul: make consul non-tunneled plugin.

### DIFF
--- a/automation/devops_automation_infra/plugins/consul.py
+++ b/automation/devops_automation_infra/plugins/consul.py
@@ -16,12 +16,8 @@ class Consul(object):
         self.OVERRIDE_KEY = "OVERRIDE"
         self.APPLICATION_KEY = "APPLICATION"
 
-    @property
-    def tunnel(self):
-        return self._host.TunnelManager.get_or_create('consul', self.DNS_NAME, self.PORT)
-
     def create_client(self):
-        return consul.Consul(*self.tunnel.host_port)
+        return consul.Consul(self._host.ip, self.PORT)
 
     @property
     def _consul(self):


### PR DESCRIPTION
We change it for 2 reasons:
1) There is no reason to tunnel consul as it is exposed to the outside
world.
2) We have an issue with tunneled connections in the following case:
   Consider that we create tunneled connection and for some reason on
host under test it is using "local bind" port that overlaps with once of
our services (for example pipeng). This will lead to the situation that
pipeng service wil not be able to start and we will receive the
following stack trace:

22:05:06  >           raise SSHCalledProcessError(temp_ex.returncode, temp_ex.cmd, temp_ex.output, temp_ex.stderr, self._host)
22:05:06  E           automation_infra.plugins.ssh_direct.SSHCalledProcessError: Command '/usr/bin/docker ps -a --format "{{.Names}}" --filter Name=".*pipeng_.*"| xargs --no-run-if-empty /usr/bin/docker restart' on host 34.254.65.176 returned non-zero exit status 123
22:05:06  E           stdout:
22:05:06  E           stderr: Error response from daemon: Cannot restart container compose_v2_pipeng_1: driver failed programming external connectivity on endpoint compose_v2_pipeng_1 (eb756d4317396edef3f237d8f2f41da6ddab31260dc07671c7d095e386ebdcd1): Error starting ****land proxy: listen tcp 0.0.0.0:50058: bind: address already in use

This is usially happens due to consul, as its ping is happening before
pipeng is started in the test. So from time to time it accidentally
takes that "pipe" pirt which causes tests to fail.