### PR TITLE
redis: adding redis k8s plugin.

### DIFF
--- a/automation/devops_automation_infra/k8s_plugins/redis.py
+++ b/automation/devops_automation_infra/k8s_plugins/redis.py
@@ -1,0 +1,22 @@
+import redis
+
+from devops_automation_infra.plugins import tunnel_manager
+from infra.model import cluster_plugins
+
+
+class Redis(object):
+
+    def __init__(self, cluster):
+        self._cluster = cluster
+
+    @property
+    def _tunnel(self):
+        master = self._cluster.master
+        return master.TunnelManager.get_or_create('redis', dns_name="redis-master", port=6379, transport=master.SSH.get_transport())
+
+    def create_client(self, db=0):
+        return redis.Redis(host="127.0.0.1", port=self._tunnel.local_port, db=db)
+
+
+cluster_plugins.register('Redis', Redis)
+


### PR DESCRIPTION
In this commit we are adding basic redis plugin that returns redis
client to the test that is connected via the master to k8s cluster.