### PR TITLE
Jenkinsfile: archive artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,8 @@ pipeline {
                     coreLib.notification()
                 }
             }
+            sh "mkdir -p build-artifacts && mv devops-automation-infra/logs build-artifacts || true"
+            archiveArtifacts artifacts: 'build-artifacts/**/*', fingerprint: true
         }
     }
 }


### PR DESCRIPTION
Currently the logs are just written.. If something fails will be easier
to figure out the problem if logs are accessible via jenkins.