### PR TITLE
guych/v3 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,9 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Automation logs
+**/logs
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/automation/devops_automation_infra/installers/docker.py
+++ b/automation/devops_automation_infra/installers/docker.py
@@ -15,6 +15,8 @@ from automation_infra.plugins.ssh_direct import SshDirect
 from devops_automation_infra.plugins.ssh import SSH
 from devops_automation_infra.plugins.tunnel_manager import TunnelManager
 from devops_automation_infra.plugins.docker_compose import DockerCompose
+from automation_infra.plugins.ip_table import Iptables
+
 
 from devops_automation_infra.plugins.consul import Consul
 from devops_automation_infra.plugins.memsql import Memsql
@@ -54,11 +56,11 @@ def install_devops_product(host, request):
 @gossip.register('setup', tags=['docker', 'devops_docker'], provides=['devops'])
 def clean(host, request):
     logging.info("running devops clean_between_tests")
-    host.TunnelManager.clear()
-    ssh.ssh_direct_connect_setup(host, request)
-    waiter.wait_nothrow(host.SshDirect.connect, timeout=30)
-    host.ProxyContainer.restart()
+    host.Iptables.reset_state()
+    host.ProxyContainer.run()
     waiter.wait_nothrow(host.SSH.connect, timeout=30)
+    host.Admin.flush_journal()
+    host.Admin.log_to_journal(f">>>>> Test {request.node.nodeid} <<<<")
 
 
 @gossip.register('teardown', tags=['docker', 'devops_docker'], provides=['devops'])

--- a/automation/devops_automation_infra/installers/docker.py
+++ b/automation/devops_automation_infra/installers/docker.py
@@ -35,7 +35,7 @@ def deploy_proxy_container(host, request):
     waiter.wait_nothrow(host.SSH.connect, timeout=30)
 
 
-@gossip.register('session_install', tags=['devops_docker'], provides=['devops_docker'])
+@gossip.register('session_install', tags=['devops_docker'])
 def install_devops_product(host, request):
     logging.info("running devops installer..")
     if request.config.getoption("--sync-time"):
@@ -53,7 +53,7 @@ def install_devops_product(host, request):
     logging.info("devops install finished!")
 
 
-@gossip.register('setup', tags=['docker', 'devops_docker'], provides=['devops'])
+@gossip.register('setup', tags=['docker', 'devops_docker'])
 def clean(host, request):
     logging.info("running devops clean_between_tests")
     host.Iptables.reset_state()

--- a/automation/devops_automation_infra/installers/docker.py
+++ b/automation/devops_automation_infra/installers/docker.py
@@ -6,6 +6,7 @@ import gossip
 from automation_infra.utils import waiter
 from compose_util.compose_manager import ComposeManager
 from compose_util.compose_options import add_cmdline_options
+from devops_automation_infra.installers import ssh
 
 from pytest_automation_infra import helpers
 
@@ -25,8 +26,9 @@ def setup():
     pass
 
 
-@gossip.register('session', tags=['docker', 'devops_docker'], needs=['ssh'], provides=['docker'])
+@gossip.register('session', tags=['docker', 'devops_docker'])
 def deploy_proxy_container(host, request):
+    ssh.ssh_direct_connect_session(host, request)
     host.ProxyContainer.run()
     waiter.wait_nothrow(host.SSH.connect, timeout=30)
 
@@ -53,6 +55,7 @@ def install_devops_product(host, request):
 def clean(host, request):
     logging.info("running devops clean_between_tests")
     host.TunnelManager.clear()
+    ssh.ssh_direct_connect_setup(host, request)
     waiter.wait_nothrow(host.SshDirect.connect, timeout=30)
     host.ProxyContainer.restart()
     waiter.wait_nothrow(host.SSH.connect, timeout=30)

--- a/automation/devops_automation_infra/installers/k8s.py
+++ b/automation/devops_automation_infra/installers/k8s.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+import logging
+import os
+import gossip
+import re
+from automation_infra.utils import waiter
+from compose_util.compose_manager import ComposeManager
+from compose_util.compose_options import add_cmdline_options
+
+
+from automation_infra.plugins.ssh_direct import SshDirect
+from devops_automation_infra.plugins.ssh import SSH
+from devops_automation_infra.k8s_plugins.proxy_daemonset import ProxyDaemonSet
+from automation_infra.utils import concurrently
+from devops_automation_infra.installers import ssh
+
+
+@gossip.register('session', tags=['k8s', 'devops_k8s'])
+def deploy_proxy_pod(cluster, request):
+    concurrently.run([lambda: ssh.ssh_direct_connect_session(host, request) for host in cluster.hosts.values()])
+    logging.info("Deploying proxy daemon-set")
+    cluster.ProxyDaemonSet.run()
+    for host in cluster.hosts.values():
+        waiter.wait_nothrow(lambda: host.SSH.connect(port=host.tunnelport), timeout=60)
+
+
+@gossip.register('session_install', tags=['devops_k8s'])
+def install_devops_product(cluster, request):
+    # TODO: Add installation of devops product
+    pass
+
+
+@gossip.register('setup', tags=['docker', 'devops_k8s'])
+def clean(cluster, request):
+    concurrently.run([lambda: ssh.ssh_direct_connect_session(host, request) for host in cluster.hosts.values()])
+    logging.info("running devops clean_base_btwn_tests")
+    cluster.ProxyDaemonSet.restart()
+    for host in cluster.hosts.values():
+        waiter.wait_nothrow(host.SSH.connect, timeout=30)
+
+
+@gossip.register('teardown', tags=['k8s', 'devops_k8s'])
+def download(cluster, request):
+    logs_dir = request.config.getoption("--logs-dir", f'logs/{datetime.now().strftime("%Y_%m_%d__%H%M_%S")}')
+    concurrently.run([lambda: download_host_logs(host, os.path.join(logs_dir, host.alias))
+                      for host in cluster.hosts.values()])
+    # concurrently.run([lambda: download_consul_logs(host, os.path.join(logs_dir, host.alias))
+    #                   for host in cluster.hosts.values() if host.Docker.container_by_name("consul")])
+
+
+def download_host_logs(host, dest_dir):
+    os.makedirs(dest_dir, exist_ok=True)
+    host.SshDirect.execute('sudo sh -c "journalctl > /tmp/journal.log"')
+    host.SshDirect.download(dest_dir, '/tmp/journal.log')
+    host.SshDirect.execute('sudo chmod ugo+rw /storage/logs &&'
+                           'sudo docker ps | grep automation-proxy-daemonset | grep -v k8s_POD | awk {\'print $1\'} |'
+                           'xargs sudo docker logs &> /storage/logs/automation_proxy.log')
+    dest_gz = '/tmp/logs.tar.gz'
+    host.SSH.compress("/storage/logs/", dest_gz)
+    host.SSH.download(re.escape(dest_dir), dest_gz)
+
+
+def download_consul_logs(host, dest_dir):
+    consul_log_dir = os.path.join(dest_dir, "consul")
+    os.makedirs(consul_log_dir, exist_ok=True)
+    host.Docker.download_container_logs("consul", consul_log_dir, tail=1000)

--- a/automation/devops_automation_infra/installers/ssh.py
+++ b/automation/devops_automation_infra/installers/ssh.py
@@ -3,14 +3,18 @@ import gossip
 
 
 @gossip.register('session', tags=['ssh'], provides=['ssh'])
-def ssh_direct_connect(host, request):
+def ssh_direct_connect_session(host, request):
+    add_ssh_agent(host)
     init_host_ssh_direct(host)
     mkdir_infra(host)
 
 
-def init_host_ssh_direct(host):
+def add_ssh_agent(host):
     if host.pkey:
         host.add_to_ssh_agent()
+
+
+def init_host_ssh_direct(host):
     logging.info(f"[{host}] waiting for ssh connection...")
     host.SshDirect.connect(timeout=60)
     logging.info(f"[{host}] success!")
@@ -18,3 +22,8 @@ def init_host_ssh_direct(host):
 
 def mkdir_infra(host):
     host.SshDirect.execute("mkdir -p -m 777 /tmp/automation_infra")
+
+
+@gossip.register('setup', tags=['ssh'], provides=['ssh'])
+def ssh_direct_connect_setup(host, request):
+    init_host_ssh_direct(host)

--- a/automation/devops_automation_infra/installers/ssh.py
+++ b/automation/devops_automation_infra/installers/ssh.py
@@ -22,8 +22,3 @@ def init_host_ssh_direct(host):
 
 def mkdir_infra(host):
     host.SshDirect.execute("mkdir -p -m 777 /tmp/automation_infra")
-
-
-@gossip.register('setup', tags=['ssh'], provides=['ssh'])
-def ssh_direct_connect_setup(host, request):
-    init_host_ssh_direct(host)

--- a/automation/devops_automation_infra/installers/ssh.py
+++ b/automation/devops_automation_infra/installers/ssh.py
@@ -2,9 +2,7 @@ import logging
 import gossip
 
 
-@gossip.register('session',
-                 tags=['ssh', 'docker', 'devops_docker', 'core_docker', 'k8s', 'devops_k8s', 'core_k8s'],
-                 provides=['ssh'])
+@gossip.register('session', tags=['ssh'], provides=['ssh'])
 def ssh_direct_connect(host, request):
     init_host_ssh_direct(host)
     mkdir_infra(host)

--- a/automation/devops_automation_infra/k8s_plugins/consul.py
+++ b/automation/devops_automation_infra/k8s_plugins/consul.py
@@ -1,0 +1,35 @@
+import json
+import base64
+import consul
+from infra.model import cluster_plugins
+from pytest_automation_infra import helpers
+from automation_infra.utils import waiter
+from devops_automation_infra.k8s_plugins.kubectl import Kubectl
+from devops_automation_infra.utils import container
+from devops_automation_infra.utils import kubectl
+
+class Consul(object):
+    def __init__(self, cluster):
+        self._cluster = cluster
+        self.NAME = "consul-server"
+        self.DNS_NAME = f'{self.NAME}.default.svc.cluster.local'
+        self.URI = "/consul"
+        self.PORT = 8500
+
+    @property
+    def _master(self):
+        return self._cluster.K8SMaster()
+
+    @property
+    def _tunnel(self):
+        return self._master.TunnelManager.get_or_create('consul', self.DNS_NAME, self.PORT)
+
+    def create_client(self):
+        host, port = self._tunnel.host_port
+        return consul.Consul(host, port)
+
+    def clear_data(self):
+        kubectl.delete_stateful_set_data(self._cluster.Kubectl.client(), self.NAME)
+
+cluster_plugins.register('Consul', Consul)
+

--- a/automation/devops_automation_infra/k8s_plugins/gravity.py
+++ b/automation/devops_automation_infra/k8s_plugins/gravity.py
@@ -5,7 +5,10 @@ from infra.model import cluster_plugins
 class Gravity:
     def __init__(self, cluster):
         self._cluster = cluster
-        self._master = self._cluster.K8SMaster()
+
+    @property
+    def _master(self):
+        return self._cluster.K8SMaster()
 
     def exec(self, command):
         return self._master.SshDirect.execute(f"sudo gravity exec {command}")

--- a/automation/devops_automation_infra/k8s_plugins/k8s_master.py
+++ b/automation/devops_automation_infra/k8s_plugins/k8s_master.py
@@ -1,3 +1,5 @@
+import logging
+
 from automation_infra.utils import waiter
 from infra.model import cluster_plugins
 from automation_infra.plugins.ssh_direct import SshDirect
@@ -8,13 +10,17 @@ class K8SMaster:
         self._cluster = cluster
 
     def __call__(self):
-        return next(iter(self.list_masters()))
+        masters = self.list_masters()
+        if len(masters) > 0:
+            return next(iter(masters))
+        else:
+            raise Exception("Couldn't find running masters nodes")
 
     def list_masters(self):
         masters = []
         for host in self._cluster.hosts.values():
             try:
-                waiter.wait_nothrow(lambda: host.SshDirect.execute("sudo kubectl get po"), timeout=100)
+                waiter.wait_nothrow(lambda: host.SshDirect.execute("sudo kubectl get po"), timeout=150)
                 masters.append(host)
             except:
                 continue

--- a/automation/devops_automation_infra/k8s_plugins/kafka.py
+++ b/automation/devops_automation_infra/k8s_plugins/kafka.py
@@ -101,6 +101,9 @@ class Kafka:
     def ping(self):
         return self.consumer().topics()
 
+    def clear_data(self):
+        kubectl.delete_stateful_set_data(self._cluster.Kubectl.client(), f"{self._name}-kafka", timeout=60 * 3)
+
 
 cluster_plugins.register('Kafka', Kafka)
 

--- a/automation/devops_automation_infra/k8s_plugins/kubectl.py
+++ b/automation/devops_automation_infra/k8s_plugins/kubectl.py
@@ -9,7 +9,10 @@ from infra.model import cluster_plugins
 class Kubectl:
     def __init__(self, cluster):
         self._cluster = cluster
-        self._master = self._cluster.K8SMaster()
+
+    @property
+    def _master(self):
+        return  self._cluster.K8SMaster()
 
     @property
     def _tunnel(self):

--- a/automation/devops_automation_infra/k8s_plugins/memsql.py
+++ b/automation/devops_automation_infra/k8s_plugins/memsql.py
@@ -1,0 +1,46 @@
+import pymysql
+from infra.model import cluster_plugins
+from pymysql.constants import CLIENT
+import copy
+from devops_automation_infra.k8s_plugins.kubectl import Kubectl
+from devops_automation_infra.utils import kubectl as kubectl_utils
+
+
+class Memsql(object):
+    def __init__(self, cluster):
+        self.DNS_NAME = 'memsql.default.svc.cluster.local'
+        self.PORT = 3306
+        self._cluster = cluster
+
+    @property
+    def _master(self):
+        return self._cluster.K8SMaster()
+
+    @property
+    def _tunnel(self):
+        return self._master.TunnelManager.get_or_create('memsql', self.DNS_NAME, self.PORT)
+
+    def connection(self, database=None, **kwargs):
+        host, port = self._tunnel.host_port
+        return self._create_connection(host=host,
+                                       port=port,
+                                       cursorclass=pymysql.cursors.DictCursor,
+                                       client_flag=CLIENT.MULTI_STATEMENTS,
+                                       database=database,
+                                       **kwargs)
+
+    @property
+    def password(self):
+        return kubectl_utils.get_secret_data(self._cluster.Kubectl.client(), namespace="default", name='memsql-secret',
+                                             path='password')
+
+    def _create_connection(self, **kwargs):
+        memsql_kwargs = copy.copy(kwargs)
+        memsql_kwargs['password'] = self.password.decode()
+        memsql_kwargs.setdefault('user', 'root')
+        memsql_kwargs.setdefault('client_flag', CLIENT.MULTI_STATEMENTS)
+        memsql_kwargs.setdefault('cursorclass', pymysql.cursors.DictCursor)
+        return pymysql.connect(**memsql_kwargs)
+
+
+cluster_plugins.register('Memsql', Memsql)

--- a/automation/devops_automation_infra/k8s_plugins/postgresql.py
+++ b/automation/devops_automation_infra/k8s_plugins/postgresql.py
@@ -1,0 +1,38 @@
+import logging
+import psycopg2
+import psycopg2.extras
+
+from infra.model import cluster_plugins
+from devops_automation_infra.utils import kubectl as kubectl_utils
+
+
+class Postgresql(object):
+    def __init__(self, cluster):
+        self._cluster = cluster
+        self.DNS = 'postgres.default.svc.cluster.local'
+        self.PORT = 5432
+
+    @property
+    def _master(self):
+        return self._cluster.K8SMaster()
+
+    @property
+    def password(self):
+        return kubectl_utils.get_secret_data(self._cluster.Kubectl.client(),
+                                             namespace="default",
+                                             name='postgres-secret',
+                                             path='password').decode()
+
+    def connection(self):
+        tunnel = self._master.TunnelManager.get_or_create('postgres', self.DNS, self.PORT)
+        connection = psycopg2.connect(host=tunnel.host_port[0],
+                                      port=tunnel.host_port[1],
+                                      user='anv_admin',
+                                      password=self.password,
+                                      database='anv_db')
+
+        return connection
+
+
+cluster_plugins.register('Postgresql', Postgresql)
+

--- a/automation/devops_automation_infra/k8s_plugins/proxy_daemonset.py
+++ b/automation/devops_automation_infra/k8s_plugins/proxy_daemonset.py
@@ -51,7 +51,7 @@ class ProxyDaemonSet(object):
         except ApiException as e:
             logging.exception("Exception when calling AppsV1Api->create_namespaced_daemon_set: %s\n" % e)
 
-        waiter.wait_nothrow(lambda: self._num_ready_pods() == len(self._cluster.hosts), timeout=30)
+        waiter.wait_for_predicate(lambda: self._num_ready_pods() == len(self._cluster.hosts), timeout=120)
         logging.debug(f"Deployment created. status={res.metadata.name}")
 
     def kill(self):

--- a/automation/devops_automation_infra/k8s_plugins/rancher.py
+++ b/automation/devops_automation_infra/k8s_plugins/rancher.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-
+import yaml
 import requests
 
 from automation_infra.plugins.ssh_direct import SSHCalledProcessError
@@ -86,6 +86,11 @@ class Rancher:
         logging.debug(cmd)
         if wait:
             self.wait_for_app(app_name, timeout)
+
+    def get_app_version(self, app_name):
+        cmd = f"rancher app ls {app_name} -o yaml"
+        app_yaml = yaml.load(self._cluster.Gravity.exec(cmd))
+        return app_yaml['Version']
 
     def install_app(self, app_name, version, image_pull_policy="Always", docker_registry="", namespace="default",
                     wait=True, timeout="120", force=True, **kwargs):

--- a/automation/devops_automation_infra/k8s_plugins/seaweed.py
+++ b/automation/devops_automation_infra/k8s_plugins/seaweed.py
@@ -1,0 +1,28 @@
+from infra.model import cluster_plugins
+from devops_automation_infra.utils import s3
+import boto3
+
+
+class Seaweed:
+    def __init__(self, cluster):
+        self._cluster = cluster
+        self.DNS = 'seaweedfs-s3.default.svc.cluster.local'
+        self.PORT = 8333
+        self.filer_host = 'seaweedfs-filer.default.svc.cluster.local'
+        self.filer_port = 8888
+
+    @property
+    def _master(self):
+        return self._cluster.K8SMaster()
+
+    @property
+    def _tunnel(self):
+        return self._master.TunnelManager.get_or_create("Seaweed-s3", self.DNS, self.PORT)
+
+    def create_client(self):
+        host, port = self._tunnel.host_port
+        return boto3.client('s3', endpoint_url=f"http://{host}:{port}",
+                          aws_secret_access_key='any',
+                          aws_access_key_id='any')
+
+cluster_plugins.register('Seaweed', Seaweed)

--- a/automation/devops_automation_infra/plugins/proxy_container.py
+++ b/automation/devops_automation_infra/plugins/proxy_container.py
@@ -94,5 +94,8 @@ class ProxyContainer(object):
     def restart(self):
         self.run()
 
+    def clear(self):
+        self.kill()
+
 
 plugins.register("ProxyContainer", ProxyContainer)

--- a/automation/devops_automation_infra/tests/v3_tests/k8s/conftest.py
+++ b/automation/devops_automation_infra/tests/v3_tests/k8s/conftest.py
@@ -1,0 +1,16 @@
+import gossip
+
+# import ssh and docker "installers" so that the handlers will be registered
+from devops_automation_infra.installers import ssh
+from devops_automation_infra.installers import docker
+
+from compose_util import compose_options
+
+
+def pytest_addoption(parser):
+    compose_options.add_cmdline_options(parser)
+
+# An example handler - will run if triggered by someone in pytest_runtest_setup
+@gossip.register("runtest_setup")
+def setup_handler():
+    pass

--- a/automation/devops_automation_infra/tests/v3_tests/k8s/test_kafka.py
+++ b/automation/devops_automation_infra/tests/v3_tests/k8s/test_kafka.py
@@ -1,6 +1,7 @@
 from pytest_automation_infra.helpers import hardware_config
 from devops_automation_infra.k8s_plugins.kafka import Kafka
 from devops_automation_infra.utils import kafka
+from core_product.installers import k8s
 import kafka as kafka_client
 from kafka import KafkaProducer
 
@@ -13,15 +14,15 @@ def example_decorator():
     return True
 
 
-# @hardware_config(hardware={"host1": {"hardware_type": "ai_camera"}},
-#                  grouping={"cluster1": {"hosts": ["host1"]}})
-# def test_kafka(base_config):
-#     host = base_config.hosts.host1
-#     cluster = base_config.clusters.cluster1
-#     cluster.Kafka.ping()
+@hardware_config(hardware={"hardware_type": "vm", "host1": {"base_image": "gravity_infra_230"}},
+                 grouping={"cluster1": {"hosts": ["host1"], "installer": "core_k8s"}})
+def test_kafka(base_config):
+    host = base_config.hosts.host1
+    cluster = base_config.clusters.cluster1
+    cluster.Kafka.ping()
 
-@hardware_config(hardware={"host1": {"hardware_type": "ai_camera"}},
-                 grouping={"cluster1": {"hosts": ["host1"]}})
+@hardware_config(hardware={"host1": {"hardware_type": "vm", "base_image": "gravity_infra_230"}},
+                 grouping={"cluster1": {"hosts": ["host1"], "installer": "core_k8s"}})
 def test_kafka_cleaned(base_config):
     host = base_config.hosts.host1
     cluster = base_config.clusters.cluster1

--- a/automation/devops_automation_infra/tests/v3_tests/k8s/test_kubectl.py
+++ b/automation/devops_automation_infra/tests/v3_tests/k8s/test_kubectl.py
@@ -3,10 +3,11 @@ import logging
 from devops_automation_infra.k8s_plugins.kubectl import Kubectl
 from devops_automation_infra.k8s_plugins.proxy_daemonset import ProxyDaemonSet
 from pytest_automation_infra.helpers import hardware_config
+from devops_automation_infra.installers import k8s
 
 
 @hardware_config(hardware={"host1": {"hardware_type": "vm", "base_image": "gravity_infra_230"}},
-                 grouping={"cluster1": {"hosts": ["host2"]}})
+                 grouping={"cluster1": {"hosts": ["host1"], "installer": "k8s"}})
 def test_kubectl(base_config):
     host = base_config.hosts.host1
     ssh = host.SshDirect

--- a/automation/devops_automation_infra/tests/v3_tests/k8s/test_memsql.py
+++ b/automation/devops_automation_infra/tests/v3_tests/k8s/test_memsql.py
@@ -1,0 +1,13 @@
+import logging
+
+from devops_automation_infra.k8s_plugins.memsql import Memsql
+from pytest_automation_infra.helpers import hardware_config
+from devops_automation_infra.installers import k8s
+from devops_automation_infra.utils import memsql
+
+@hardware_config(hardware={"host1": {"hardware_type": "vm", "base_image": "gravity_infra_230"}},
+                 grouping={"cluster1": {"hosts": ["host1"], "installer": "k8s"}})
+def test_memsql(base_config):
+    cluster = base_config.clusters.cluster1
+    memsql_client = cluster.Memsql.connection()
+    memsql.truncate_all(memsql_client)

--- a/automation/devops_automation_infra/utils/aws_s3.py
+++ b/automation/devops_automation_infra/utils/aws_s3.py
@@ -1,0 +1,11 @@
+import boto3
+import os
+
+def create_aws_s3_connection():
+    _is_aws_cred_path_exists()
+    s3 = boto3.client('s3')  # Configure locally access keys on local machine in ~/.aws, this will use them
+    return s3
+
+def _is_aws_cred_path_exists():
+    if not os.path.exists(f'{os.path.expanduser("~")}/.aws'):
+        raise FileNotFoundError("Missing aws credentials in ~/.aws folder")

--- a/automation/devops_automation_infra/utils/consul.py
+++ b/automation/devops_automation_infra/utils/consul.py
@@ -2,6 +2,13 @@ import os
 import pickle
 import logging
 from automation_infra.plugins.ssh_direct import SSHCalledProcessError
+import consul
+
+def get_services(client):
+    return client.catalog.services()[1]
+
+def get_service_nodes(client, service_name):
+    return client.catalog.service(service_name)[1]
 
 def backup_consul_keys(host):
     try:

--- a/automation/devops_automation_infra/utils/kafka.py
+++ b/automation/devops_automation_infra/utils/kafka.py
@@ -1,5 +1,6 @@
 from kafka.admin import ConfigResource
 from automation_infra.utils import waiter
+import kubernetes
 
 
 def clear_all_topics(admin, consumer):
@@ -43,3 +44,13 @@ def update_topic_config(admin, topic_name, body):
         raise Exception(
             f"Failed to update topic {topic_name}: {alter_config_response['resources'][0]['error_message']}")
 
+
+def update_retention_check_interval(k8s_client, kafka_name, namespace="default", interval=1000):
+    custom_object_client = kubernetes.client.CustomObjectsApi(k8s_client)
+    body = {"spec": {"kafka": {"config": {"log.retention.check.interval.ms": interval}}}}
+    custom_object_client.patch_namespaced_custom_object(namespace=namespace,
+                                                        group='kafka.strimzi.io',
+                                                        version='v1beta1',
+                                                        plural='kafkas',
+                                                        name=kafka_name,
+                                                        body=body)

--- a/automation/devops_automation_infra/utils/kubectl.py
+++ b/automation/devops_automation_infra/utils/kubectl.py
@@ -72,3 +72,12 @@ def delete_pvc(client, name, namespace='default', clear_data=False):
         pv_name = v1.read_namespaced_persistent_volume_claim(name=name, namespace=namespace).spec.volume_name
         v1.patch_persistent_volume(name=pv_name, body={'spec': {'persistentVolumeReclaimPolicy': 'Delete'}})
     v1.delete_namespaced_persistent_volume_claim(name=name, namespace=namespace)
+
+
+def get_job_status(client, job_name, namespace='default'):
+    v1 = kubernetes.client.BatchV1Api(client)
+    return v1.read_namespaced_job(namespace=namespace, name=job_name).status
+
+
+def wait_for_job_to_succeed(client, job_name, namespace='default', timeout=60):
+    waiter.wait_for_predicate(lambda: get_job_status(client, namespace=namespace, job_name=job_name).succeeded == 1, timeout=timeout)

--- a/automation/devops_automation_infra/utils/kubectl.py
+++ b/automation/devops_automation_infra/utils/kubectl.py
@@ -53,10 +53,8 @@ def pod_exec(kubectl_client, namespace, name, command, executable="/bin/bash"):
 
 def get_secret_data(kubectl_client, namespace, name, path, decode=True):
     corev1api = kubernetes.client.CoreV1Api(kubectl_client)
-    secret_list = corev1api.list_namespaced_secret(namespace)
-    for secret in secret_list.items:
-        if secret.metadata.name == name:
-            return base64.b64decode(secret.data[path]) if decode else secret.data[path]
+    secret = corev1api.read_namespaced_secret(namespace=namespace, name=name)
+    return base64.b64decode(secret.data[path]) if decode else secret.data[path]
 
 
 def scale_stateful_set(client, replicas, name, namespace='default'):

--- a/automation/devops_automation_infra/utils/kubectl.py
+++ b/automation/devops_automation_infra/utils/kubectl.py
@@ -5,6 +5,7 @@ from kubernetes.client import ApiException
 import kubernetes
 from kubernetes.stream import stream
 from automation_infra.utils import waiter
+import uuid
 
 
 def get_pods_by_label(kubectl_client, label, namespace='default'):
@@ -43,6 +44,11 @@ def is_stateful_set_ready(client, name, namespace='default'):
     return sts.status.replicas == sts.status.ready_replicas
 
 
+def is_deployment_ready(client, name, namespace='default'):
+    v1 = kubernetes.client.AppsV1Api(client)
+    deployment = v1.read_namespaced_deployment(name=name, namespace=namespace)
+    return deployment.status.replicas == deployment.status.ready_replicas
+
 def pod_exec(kubectl_client, namespace, name, command, executable="/bin/bash"):
     corev1api = kubernetes.client.CoreV1Api(kubectl_client)
     response = stream(corev1api.connect_get_namespaced_pod_exec,
@@ -57,10 +63,17 @@ def get_secret_data(kubectl_client, namespace, name, path, decode=True):
     return base64.b64decode(secret.data[path]) if decode else secret.data[path]
 
 
-def scale_stateful_set(client, replicas, name, namespace='default'):
+def scale_stateful_set(client, replicas, name, namespace='default', timeout=30):
     v1 = kubernetes.client.AppsV1Api(client)
     v1.patch_namespaced_stateful_set_scale(name=name, namespace=namespace, body={'spec': {'replicas': replicas}})
     waiter.wait_for_predicate(lambda: v1.read_namespaced_stateful_set_scale(name=name, namespace=namespace).status.replicas
+                              == replicas, timeout=timeout)
+
+
+def scale_deployment(client, replicas, name, namespace='default'):
+    v1 = kubernetes.client.AppsV1Api(client)
+    v1.patch_namespaced_deployment_scale(name=name, namespace=namespace, body={'spec': {'replicas': replicas}})
+    waiter.wait_for_predicate(lambda: v1.read_namespaced_deployment_scale(name=name, namespace=namespace).status.replicas
                               == replicas, timeout=30)
 
 
@@ -70,6 +83,80 @@ def delete_pvc(client, name, namespace='default', clear_data=False):
         pv_name = v1.read_namespaced_persistent_volume_claim(name=name, namespace=namespace).spec.volume_name
         v1.patch_persistent_volume(name=pv_name, body={'spec': {'persistentVolumeReclaimPolicy': 'Delete'}})
     v1.delete_namespaced_persistent_volume_claim(name=name, namespace=namespace)
+
+
+def delete_stateful_set_data(client, name, namespace='default', clear_data=False, timeout=60):
+    v1_app = kubernetes.client.AppsV1Api(client)
+    sts_spec = v1_app.read_namespaced_stateful_set(name=name, namespace=namespace).spec
+    replicas = sts_spec.replicas
+
+    scale_stateful_set(client, 0, name, namespace)
+
+    claim_templates = [volume.metadata.name for volume in sts_spec.volume_claim_templates]
+    pvcs_to_delete = []
+
+    for template in claim_templates:
+        for i in range(0, replicas):
+            pvcs_to_delete.append(f"{template}-{name}-{i}")
+
+    for pvc in pvcs_to_delete:
+        delete_pvc(client, pvc, namespace, clear_data)
+
+    scale_stateful_set(client, replicas, name, namespace, timeout=60)
+    waiter.wait_for_predicate(lambda :is_stateful_set_ready(client, name), timeout=timeout)
+
+
+def delete_deployment_data(client, name, namespace='default', clear_data=False):
+    v1_app = kubernetes.client.AppsV1Api(client)
+    deployment_spec = v1_app.read_namespaced_deployment(name=name, namespace=namespace).spec
+    replicas = deployment_spec.replicas
+
+    scale_deployment(client, 0, name, namespace)
+
+    pvcs_to_delete = [volume.persistent_volume_claim.claim_name for volume in deployment_spec.template.spec.volumes
+                      if volume.persistent_volume_claim ]
+    for pvc in pvcs_to_delete:
+        delete_pvc(client, pvc, namespace, clear_data)
+
+    scale_deployment(client, replicas, name, namespace)
+
+
+def recycle_pvc(client, pvc_name, namespace='default', timeout=60):
+    k8s_client = kubernetes.client
+    v1 = k8s_client.CoreV1Api(client)
+    try:
+        v1.read_namespaced_persistent_volume_claim(name=pvc_name, namespace=namespace)
+    except ApiException as e:
+        if e.status == 404:
+            raise ApiException(f"Couldn't find pvc {pvc_name} in namespace {namespace}")
+
+    container = kubernetes.client.V1Container(
+        name="pv-cleaner",
+        command=["/bin/sh", "-c", "rm -rf /scrub/*"],
+        image="k8s.gcr.io/busybox",
+        volume_mounts=[k8s_client.V1VolumeMount(name="pvc-volume", mount_path="/scrub")]
+    )
+
+    volume = k8s_client.V1Volume(
+        name="pvc-volume",
+        persistent_volume_claim = k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=pvc_name))
+    pod_spec = k8s_client.V1PodSpec(volumes=[volume], containers=[container], restart_policy="Never")
+    pod_name = f"pv-cleaner-{str(uuid.uuid4())[:6]}"
+    pod = k8s_client.V1Pod(metadata=k8s_client.V1ObjectMeta(name=pod_name), spec=pod_spec)
+
+    v1 = k8s_client.CoreV1Api(client)
+    v1.create_namespaced_pod(namespace=namespace, body=pod)
+
+    try:
+        waiter.wait_for_predicate(
+            lambda: v1.read_namespaced_pod(
+                name=pod_name, namespace=namespace).status.phase == "Succeeded", timeout=timeout)
+
+    except TimeoutError as e:
+        logging.debug(v1.read_namespaced_pod(name=pod_name, namespace=namespace).status)
+        raise e
+
+    v1.delete_namespaced_pod(name=pod_name, namespace=namespace)
 
 
 def get_job_status(client, job_name, namespace='default'):

--- a/automation/devops_automation_infra/utils/memsql.py
+++ b/automation/devops_automation_infra/utils/memsql.py
@@ -1,36 +1,24 @@
 import logging
 import pymysql
-
+from devops_automation_infra.utils import sql
 
 def truncate_all(connection):
     logging.debug('Truncating all memsql dbs')
-    truncate_commands = fetchall(connection,
+    truncate_commands = sql.fetchall(connection,
                                  f"""select concat('truncate table ', TABLE_SCHEMA, '.', TABLE_NAME) as truncate_command
                                     from information_schema.tables t
                                     where TABLE_SCHEMA not in ('information_schema', 'memsql')
                                     and TABLE_NAME not in ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK'); """)
 
     commands = ''.join([f"{command['truncate_command']};" for command in truncate_commands])
-    execute(connection=connection, query=commands)
+    sql.execute(connection=connection, query=commands)
     logging.debug('Done Truncating all memsql dbs')
 
-
-def execute(connection, query):
-    with connection.cursor() as c:
-        res = c.execute(query)
-    connection.commit()
-    return res
-
-
-def fetchall(connection, query):
-    with connection.cursor() as c:
-        c.execute(query)
-        return c.fetchall()
 
 
 def get_pipeline_partitions(connection, pipeline):
     query = f"select SOURCE_PARTITION_ID from information_schema.pipelines_cursors WHERE PIPELINE_NAME=\"{pipeline}\""
-    result = fetchall(connection, query)
+    result = sql.fetchall(connection, query)
     return [partition['SOURCE_PARTITION_ID'] for partition in result]
 
 
@@ -41,7 +29,7 @@ def delete_pipeline_partitions(connection, pipeline, *partitions):
     queries = [f"ALTER PIPELINE {pipeline} DROP PARTITION '{partition}'"
                     for partition in partitions]
     joined = ";".join(queries)
-    execute(connection, joined)
+    sql.execute(connection, joined)
 
 
 def reset_pipeline(connection, pipeline_name):
@@ -49,7 +37,7 @@ def reset_pipeline(connection, pipeline_name):
     logging.debug(f'Reset pipeline {pipeline_name}')
 
     try:
-        execute(connection, f"stop pipeline {pipeline_name};")
+        sql.execute(connection, f"stop pipeline {pipeline_name};")
     except pymysql.err.InternalError as e:
         logging.debug('pipeline might be stopped in this case just continue')
         err_code = e.args[0]
@@ -57,6 +45,6 @@ def reset_pipeline(connection, pipeline_name):
         if err_code != PIPELINE_ALREADY_STOPPED:
             raise
 
-    execute(connection, f"alter pipeline {pipeline_name} set offsets earliest;")
+    sql.execute(connection, f"alter pipeline {pipeline_name} set offsets earliest;")
     delete_pipeline_partitions(connection, pipeline_name)
-    execute(connection, f"start pipeline {pipeline_name};")
+    sql.execute(connection, f"start pipeline {pipeline_name};")

--- a/automation/devops_automation_infra/utils/memsql.py
+++ b/automation/devops_automation_infra/utils/memsql.py
@@ -1,0 +1,62 @@
+import logging
+import pymysql
+
+
+def truncate_all(connection):
+    logging.debug('Truncating all memsql dbs')
+    truncate_commands = fetchall(connection,
+                                 f"""select concat('truncate table ', TABLE_SCHEMA, '.', TABLE_NAME) as truncate_command
+                                    from information_schema.tables t
+                                    where TABLE_SCHEMA not in ('information_schema', 'memsql')
+                                    and TABLE_NAME not in ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK'); """)
+
+    commands = ''.join([f"{command['truncate_command']};" for command in truncate_commands])
+    execute(connection=connection, query=commands)
+    logging.debug('Done Truncating all memsql dbs')
+
+
+def execute(connection, query):
+    with connection.cursor() as c:
+        res = c.execute(query)
+    connection.commit()
+    return res
+
+
+def fetchall(connection, query):
+    with connection.cursor() as c:
+        c.execute(query)
+        return c.fetchall()
+
+
+def get_pipeline_partitions(connection, pipeline):
+    query = f"select SOURCE_PARTITION_ID from information_schema.pipelines_cursors WHERE PIPELINE_NAME=\"{pipeline}\""
+    result = fetchall(connection, query)
+    return [partition['SOURCE_PARTITION_ID'] for partition in result]
+
+
+def delete_pipeline_partitions(connection, pipeline, *partitions):
+    partitions = partitions or get_pipeline_partitions(connection, pipeline)
+    if not partitions:
+        return
+    queries = [f"ALTER PIPELINE {pipeline} DROP PARTITION '{partition}'"
+                    for partition in partitions]
+    joined = ";".join(queries)
+    execute(connection, joined)
+
+
+def reset_pipeline(connection, pipeline_name):
+    import pdb; pdb.set_trace()
+    logging.debug(f'Reset pipeline {pipeline_name}')
+
+    try:
+        execute(connection, f"stop pipeline {pipeline_name};")
+    except pymysql.err.InternalError as e:
+        logging.debug('pipeline might be stopped in this case just continue')
+        err_code = e.args[0]
+        PIPELINE_ALREADY_STOPPED = 1939
+        if err_code != PIPELINE_ALREADY_STOPPED:
+            raise
+
+    execute(connection, f"alter pipeline {pipeline_name} set offsets earliest;")
+    delete_pipeline_partitions(connection, pipeline_name)
+    execute(connection, f"start pipeline {pipeline_name};")

--- a/automation/devops_automation_infra/utils/postgresql.py
+++ b/automation/devops_automation_infra/utils/postgresql.py
@@ -1,0 +1,13 @@
+from devops_automation_infra.utils import sql
+
+
+def truncate_all(connection):
+    queries = "TRUNCATE TABLE cameras CASCADE;" \
+              "TRUNCATE TABLE cameras_2_regions CASCADE;" \
+              "TRUNCATE TABLE regions CASCADE;" \
+              "TRUNCATE TABLE tracks CASCADE;" \
+              "DELETE from camera_groups WHERE \"isDefault\" = False;"
+
+    sql.execute(connection, queries)
+    connection.rollback()
+    connection.reset()

--- a/automation/devops_automation_infra/utils/s3.py
+++ b/automation/devops_automation_infra/utils/s3.py
@@ -1,0 +1,13 @@
+import os
+
+def download_file_to_filesystem(boto3_client, remote_path, local_dir=".", bucketname="anyvision-testing"):
+    if not os.path.exists(local_dir):
+        os.makedirs(local_dir)
+
+    local_file_path = os.path.join(local_dir, os.path.basename(remote_path))
+    boto3_client.download_file(bucketname, remote_path, local_file_path)
+    return local_file_path
+
+def download_files_to_filesystem(boto3_client, remote_files, local_dir=".", bucketname="anyvision-testing"):
+    for file in remote_files:
+        download_file_to_filesystem(boto3_client, file, local_dir, bucketname)

--- a/automation/devops_automation_infra/utils/sql.py
+++ b/automation/devops_automation_infra/utils/sql.py
@@ -1,0 +1,14 @@
+
+
+
+def execute(connection, query):
+    with connection.cursor() as c:
+        res = c.execute(query)
+    connection.commit()
+    return res
+
+
+def fetchall(connection, query):
+    with connection.cursor() as c:
+        c.execute(query)
+        return c.fetchall()

--- a/run/v3/local.sh
+++ b/run/v3/local.sh
@@ -6,8 +6,23 @@ if [ "$1" == "-h" ]; then
   exit 0
 fi
 
+install=""
+while test $# -gt 0
+do
+  case $1 in
+    --install)
+      install="--sf=\"--install --yaml-file=docker-compose-devops.yml\""
+      ;;
+    *)
+      break
+      ;;
+  esac
+  echo "$1"
+  shift
+done
+
 script_dir=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
 prefix="$script_dir/../../../automation-infra/containerize.sh python -m pytest -p pytest_subprocessor --sf=\"-p pytest_automation_infra \" -s  --noconftest"
-echo "running command: $prefix $@"
+echo "running command: $prefix $install $*"
 sleep 3
-$prefix $@
+$prefix $install $*


### PR DESCRIPTION
- installers/ssh.py: remove irrelevant flags
- installers/ssh.py: register to setup stage
- installers/docker.py: add call to ssh installer stages
- proxy_container.py: added clear() method
- v3/local.sh: add --install flag
- installers/docker.py: fixes
- installers/ssh.py: remove setup implementation
- Kubectl: Added utils
- Docker installer: Remove 'provides' tags from gossip stages
- Docker installer: Download host logs in 'teardown'
- Cluster-plugins: move master from init to property method
- K8s Master: raise and error when masters aren't available
- Proxy daemonset: Fix bad waiter check
- Rancher: Plugin fixes
- Kubectl utils: Added wait for job util
- Automation: Move kafka k8s test to v3 tests
- Kafka util: Added util to update operator check interval
- Automation: Added k8s installer
- Git: Added logs dir to gitignore
