### PR TITLE
K8s-master: refactor logic of getting master node

### DIFF
--- a/automation/devops_automation_infra/k8s_plugins/k8s_master.py
+++ b/automation/devops_automation_infra/k8s_plugins/k8s_master.py
@@ -1,30 +1,28 @@
-import logging
-
-from automation_infra.utils import waiter
 from infra.model import cluster_plugins
 from automation_infra.plugins.ssh_direct import SshDirect
-
+from automation_infra.utils import concurrently, waiter
+from functools import partial
 
 class K8SMaster:
     def __init__(self, cluster):
         self._cluster = cluster
 
     def __call__(self):
-        masters = waiter.wait_nothrow(lambda: self.list_masters(), timeout=150)
-        if len(masters) > 0:
-            return masters[0]
-        else:
+        jobs = {host.ip:
+                partial(self._kubectl, host)
+                for host in self._cluster.hosts.values()}
+
+        bg = concurrently.Background(jobs)
+        bg.start()
+        master_ip = next(iter(bg.wait(return_when=concurrently.Completion.WAIT_FIRST_SUCCESS).keys()))
+        master = next(host for host in self._cluster.hosts.values() if host.ip == master_ip)
+        if not master:
             raise Exception("Couldn't find running masters nodes")
 
-    def list_masters(self):
-        masters = []
-        for host in self._cluster.hosts.values():
-            try:
-                host.SshDirect.execute("sudo kubectl get po")
-                masters.append(host)
-            except:
-                continue
-        return masters
+        return master
 
+
+    def _kubectl(self, host):
+        return waiter.wait_nothrow(lambda: host.SshDirect.execute("sudo kubectl get po"), timeout=150)
 
 cluster_plugins.register('K8SMaster', K8SMaster)


### PR DESCRIPTION
Run concurrent jobs on all nodes which checks if the node
is an active functional master node by running
kubectl command on the node.
The first host which passed the check without an error,
is returned as the k8s-master without waiting for
all other jobs to end.