### PR TITLE
K3s installer: ignore initial k3s error

### DIFF
--- a/automation/devops_automation_infra/installers/k3s.py
+++ b/automation/devops_automation_infra/installers/k3s.py
@@ -30,7 +30,7 @@ def setup_cluster(cluster, request):
     main_master.k8s_name = "k3s-master"
 
     main_master.SshDirect.execute(
-        "curl -sfL https://get.k3s.io | sh -s - --cluster-init --cluster-reset --cluster-reset-restore-path=/root/k3s-infra-1174-snapshot")
+        "curl -sfL https://get.k3s.io | sh -s - --cluster-init --cluster-reset --cluster-reset-restore-path=/root/k3s-infra-1174-snapshot || true")
     waiter.wait_nothrow(lambda: main_master.SshDirect.execute("journalctl --since='1 min ago' | grep 'restart without'"))
     main_master.SshDirect.execute(
         "curl -sfL https://get.k3s.io | sh -s - --node-name=k3s-master --disable='servicelb,traefik,local-storage,metrics-server'")


### PR DESCRIPTION
In order to start k3s server we need to restore etcd data from sanpshot.
The initial start command results with error because the service isn't
starting, it needs to have another reset without 'cluster-reset' and
'cluster-init' flags.

The error caused the installation to fail, this commit ignores the error
then continues with the second restart which is needed to start the
server