### PR TITLE
:sparkles: automation | Add get_keys in redis plugin | redis.py

### DIFF
--- a/automation/devops_automation_infra/plugins/redis.py
+++ b/automation/devops_automation_infra/plugins/redis.py
@@ -22,7 +22,10 @@ class Redis(object):
     @property
     def _redis(self):
         return self.create_client()
-    
+
+    def get_keys(self, pattern="*"):
+        return [k.decode("utf-8") for k in self._redis.keys(pattern)]
+
     def set_key(self, key, value):
         return self._redis.set(key, value)
 


### PR DESCRIPTION
Added get_keys function which returns all the keys that match the specific pattern given. (Needed for pipe-manager to get keys from redis with the pattern: `lbpm-172.17.0.1:60010:load:*`