### PR TITLE
Memsql utils | remove unnecessary pdb

### DIFF
--- a/automation/devops_automation_infra/utils/memsql.py
+++ b/automation/devops_automation_infra/utils/memsql.py
@@ -33,7 +33,6 @@ def delete_pipeline_partitions(connection, pipeline, *partitions):
 
 
 def reset_pipeline(connection, pipeline_name):
-    import pdb; pdb.set_trace()
     logging.debug(f'Reset pipeline {pipeline_name}')
 
     try:


### PR DESCRIPTION
Removed unnecessary pdb from the memsql utils reset_pipeline function