### PR TITLE
Automation | Changes to match 2.5.0 k3s & infra version

### DIFF
--- a/automation/devops_automation_infra/installers/k3s.py
+++ b/automation/devops_automation_infra/installers/k3s.py
@@ -12,7 +12,7 @@ from automation_infra.plugins.ssh_direct import SshDirect
 from devops_automation_infra.utils import kubectl
 from devops_automation_infra.installers import k8s
 
-K3S_VERSION='v1.21.5+k3s2'
+K3S_VERSION='v1.19.11+k3s1'
 
 @gossip.register('session', tags=['k3s', 'devops_k3s'])
 def setup_cluster(cluster, request):
@@ -28,16 +28,16 @@ def setup_cluster(cluster, request):
     if not masters:
         raise Exception("Couldn't find any master node")
     main_master = next(iter(masters))
-    main_master.k8s_name = "k3s-master"
+    main_master.k8s_name = "master1"
 
     main_master.SshDirect.execute(
-        f"curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION={K3S_VERSION} sh -s - --cluster-init --cluster-reset --cluster-reset-restore-path=/root/k3s-infra-1174-snapshot || true")
+        f"curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION={K3S_VERSION} sh -s - --cluster-init --cluster-reset --cluster-reset-restore-path=/root/k3s-infra-119-snapshot || true")
     waiter.wait_nothrow(lambda: main_master.SshDirect.execute("journalctl --since='1 min ago' | grep 'restart without'"))
     time.sleep(15)
     main_master.SshDirect.execute(
-        f"curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION={K3S_VERSION}  sh -s - --node-name=k3s-master --disable='servicelb,traefik,local-storage,metrics-server'")
+        f"curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION={K3S_VERSION}  sh -s - --node-name={main_master.k8s_name} --disable='servicelb,traefik,local-storage,metrics-server'")
 
-    main_master.SshDirect.execute("sudo chmod o+r /etc/rancher/k3s/k3s.yaml")
+    main_master.SshDirect.execute("sudo cp /root/.kube/config ~/.kube/config && sudo chmod o+r ~/.kube/config")
     cluster_token = main_master.SshDirect.execute("sudo cat /var/lib/rancher/k3s/server/token").strip()
     cluster_ip = main_master.SshDirect.execute("hostname -I").strip()
     waiter.wait_nothrow(lambda: main_master.SshDirect.execute("kubectl get nodes"))
@@ -56,7 +56,8 @@ def setup_cluster(cluster, request):
     logging.info("Waiting for cluster to be Ready...")
     k8s_client = cluster.Kubectl.client()
     v1 = kubernetes.client.CoreV1Api(k8s_client)
-    waiter.wait_for_predicate(lambda: len(v1.list_node().items) == len(hosts), timeout=30)
+    logging.info(f"kubectl local endpoint: {k8s_client.configuration.host}")
+    waiter.wait_for_predicate_nothrow(lambda: len(v1.list_node().items) == len(hosts), timeout=60)
     logging.info(f"Number of nodes in cluster: {len(v1.list_node().items)}")
     waiter.wait_for_predicate(lambda: kubectl.is_cluster_ready(k8s_client), timeout=60)
 
@@ -78,7 +79,7 @@ def _join_master(host, cluster_ip, cluster_token):
     ssh.execute("sudo systemctl stop k3s")
     ssh.execute("sudo rm -rf /var/lib/rancher/k3s/server")
     ssh.execute(join_cmd)
-    ssh.execute("sudo chmod o+r /etc/rancher/k3s/k3s.yaml")
+    ssh.execute("sudo cp /root/.kube/config ~/.kube/config && sudo chmod o+r ~/.kube/config")
     waiter.wait_nothrow(lambda: host.SshDirect.execute("sudo kubectl get nodes"), timeout=60)
 
 
@@ -89,7 +90,7 @@ def _label_and_taint_nodes(k8s_client, hosts):
         """
         In order to link between host from hardware request and k8s node, we need to check if the internal ip
         listed in etcd matches the internal ip of the host, for the initials master there's no need to do so
-        because we already know what's his k8s node name (k3s-master). 
+        because we already know what's his k8s node name (master1). 
         """
         if not hasattr(host, "k8s_name"):
             for k8s_node in v1.list_node().items:

--- a/automation/devops_automation_infra/k8s_plugins/kubectl.py
+++ b/automation/devops_automation_infra/k8s_plugins/kubectl.py
@@ -21,8 +21,10 @@ class Kubectl:
     @property
     def _tunnel(self):
         ssh = self._master.SshDirect
-        svc_ip = ssh.execute('sudo kubectl get svc kubernetes -o jsonpath={.spec.clusterIP}')
-        svc_port = ssh.execute('sudo kubectl get svc kubernetes -o jsonpath={.spec.ports[0].port}')
+        #svc_ip = ssh.execute('sudo kubectl get svc kubernetes -o jsonpath={.spec.clusterIP}')
+        #svc_port = ssh.execute('sudo kubectl get svc kubernetes -o jsonpath={.spec.ports[0].port}')
+        svc_ip = "127.0.0.1"
+        svc_port = 6443
         tunnel = self._master.TunnelManager.get_or_create('kubectl', svc_ip, svc_port, ssh.get_transport())
         return tunnel
 

--- a/automation/devops_automation_infra/k8s_plugins/rancher.py
+++ b/automation/devops_automation_infra/k8s_plugins/rancher.py
@@ -126,7 +126,7 @@ class Rancher:
             if wait:
                 self.wait_for_app(app_name, timeout)
             # Due to Rancher bug when app shows it's active few seconds after deployment
-            time.sleep(10)
+            time.sleep(15)
 
     def delete_app(self, app_name):
         self.cli_execute(f"rancher app delete {app_name}")


### PR DESCRIPTION
- Downgraded k3s version to v1.19.11+k3s1 (delivered in 2.5.0)
- kubectl config path was changed in this version as well as k8s api endpoint

- Added 15s timeout due to Rancher bug which shows that the layer
  is active few seconds after deployment event if it's not.