### PR TITLE
:bug: proxy pod on any node beside jetson

### DIFF
--- a/automation/proxy_container/daemonset.yaml
+++ b/automation/proxy_container/daemonset.yaml
@@ -34,8 +34,6 @@ spec:
           mountPath: /storage/logs
       tolerations:
       - operator: Exists # matches all keys, values and effects which means this will tolerate everything
-      nodeSelector:
-        node-role.kubernetes.io/master: "true"
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
since we want to get a automation proxy pod for every node in our cluster for faster data trnasfer in some specific senarios, we need to remove the node selector who make the proxy pod the scale as masters->only one